### PR TITLE
Added WPF & WinForms options to template list

### DIFF
--- a/media/index.html
+++ b/media/index.html
@@ -17,6 +17,12 @@
     <option value="blazorwasm">Blazor WebAssembly App</option>
     <option value="console" selected="selected">Console Application</option>
     <option value="classlib">Class Library</option>
+    <option value="winforms">Windows Forms Application</option>
+    <option value="winformslib">Windows Forms Library</option>
+    <option value="wpf">WPF Application</option>
+    <option value="wpfl">WPF Class Library</option>
+    <option value="wpfcustomcontrollib">WPF Custom Control Library</option>
+    <option value="wpfusercontrollib">WPF User Control Library</option>
     <option value="web">ASP.NET Core Empty</option>
     <option value="mvc">ASP.NET Core MVC</option>
     <option value="webapp">ASP.NET Core MVC Razor Page</option>

--- a/out/resource/createProjectWebView/CreateProject.js
+++ b/out/resource/createProjectWebView/CreateProject.js
@@ -182,6 +182,12 @@ class CreateProjectPanel {
     <option value="blazorwasm">Blazor WebAssembly App</option>
     <option value="console">Console Application</option>
     <option value="classlib">Class Library</option>
+    <option value="winforms">Windows Forms Application</option>
+    <option value="winformslib">Windows Forms Library</option>
+    <option value="wpf">WPF Application</option>
+    <option value="wpfl">WPF Class Library</option>
+    <option value="wpfcustomcontrollib">WPF Custom Control Library</option>
+    <option value="wpfusercontrollib">WPF User Control Library</option>
     <option value="web">ASP.NET Core Empty</option>
     <option value="mvc">ASP.NET Core MVC</option>
     <option value="webapp">ASP.NET Core MVC Razor Page</option>

--- a/src/resource/createProjectWebView/CreateProject.ts
+++ b/src/resource/createProjectWebView/CreateProject.ts
@@ -213,6 +213,12 @@ export class CreateProjectPanel {
     <option value="blazorwasm">Blazor WebAssembly App</option>
     <option value="console">Console Application</option>
     <option value="classlib">Class Library</option>
+    <option value="winforms">Windows Forms Application</option>
+    <option value="winformslib">Windows Forms Library</option>
+    <option value="wpf">WPF Application</option>
+    <option value="wpfl">WPF Class Library</option>
+    <option value="wpfcustomcontrollib">WPF Custom Control Library</option>
+    <option value="wpfusercontrollib">WPF User Control Library</option>
     <option value="web">ASP.NET Core Empty</option>
     <option value="mvc">ASP.NET Core MVC</option>
     <option value="webapp">ASP.NET Core MVC Razor Page</option>


### PR DESCRIPTION
Not sure if you're keeping the list short for usability or other reasons. But as I (inadvisedly, perhaps) sometimes use VS Code for Win32 ui application development, having WinForms & especially WPF templates as options would be useful.

If not the whole battery, then at least the basic "wpf" and "winforms" templates…

(As these are only runnable on win32, perhaps a "include windows-specific projects" checkbox might be a good alternative solution, hiding wpf/winforms for pure crossplatform devs?)